### PR TITLE
properly feature-gate allow-unknown-fields

### DIFF
--- a/packages/schema-derive/Cargo.toml
+++ b/packages/schema-derive/Cargo.toml
@@ -14,3 +14,6 @@ syn = { version = "1", features = ["full", "printing", "extra-traits"] }
 
 [lib]
 proc-macro = true
+
+[features]
+allow-unknown-fields = []

--- a/packages/schema/Cargo.toml
+++ b/packages/schema/Cargo.toml
@@ -21,4 +21,4 @@ semver = "1"
 tempfile = "3"
 
 [features]
-allow-unknown-fields = []
+allow-unknown-fields = ["cosmwasm-schema-derive/allow-unknown-fields"]


### PR DESCRIPTION
The previous PR added the feature, but it was in the proc macro which required that the _caller_ have the feature.

This now fixes it so that the feature needs to only be set in the schema-derive (or schema) crate