### PR TITLE
fix schema test

### DIFF
--- a/packages/schema-derive/src/cw_serde.rs
+++ b/packages/schema-derive/src/cw_serde.rs
@@ -73,6 +73,7 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
+            #[serde(crate = "::cosmwasm_schema::serde")]
             #unknown_fields
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {
@@ -102,6 +103,7 @@ mod tests {
                 ::cosmwasm_schema::schemars::JsonSchema
             )]
             #[allow(clippy::derive_partial_eq_without_eq)]
+            #[serde(crate = "::cosmwasm_schema::serde")]
             #unknown_fields
             #[schemars(crate = "::cosmwasm_schema::schemars")]
             pub struct InstantiateMsg {}


### PR DESCRIPTION
sorry @lvn-rusty-dragon - very minor PR, doesn't affect main perps commit pinning

long story short - the cosmwasm tests do a literal comparison against the generated struct, and I had forgotten to copy over an attribute. This is _only_ in the test code - but if you want me to update main perps to this commit too, lmk